### PR TITLE
Add the helm_param api_versions to the class

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "gitlab-runner",
       "slug": "gitlab-runner",
       "parameter_key": "gitlab_runner",
-      "test_cases": "defaults",
+      "test_cases": "defaults registration-url monitoring-metrics",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
       matrix:
         instance:
           - defaults
+          - registration-url
+          - monitoring-metrics
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - defaults
           - registration-url
+          - monitoring-metrics
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/registration-url.yml
+test_instances = tests/defaults.yml tests/registration-url.yml tests/monitoring-metrics.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,4 +9,3 @@ parameters:
         source: https://charts.gitlab.io
         version: v0.50.1
     helm_values: {}
-

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,3 +9,5 @@ parameters:
         source: https://charts.gitlab.io
         version: v0.50.1
     helm_values: {}
+    helm_params:
+      api_versions: monitoring.coreos.com/v1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,5 +9,4 @@ parameters:
         source: https://charts.gitlab.io
         version: v0.50.1
     helm_values: {}
-    helm_params:
-      api_versions: monitoring.coreos.com/v1
+

--- a/class/gitlab-runner.yml
+++ b/class/gitlab-runner.yml
@@ -16,7 +16,7 @@ parameters:
         helm_params:
           name: gitlab-runner
           namespace: ${gitlab_runner:namespace}
-          api_versions: ${gitlab_runner:helm_params:api_versions}
+          api_versions: monitoring.coreos.com/v1
       - input_paths:
           - ${_base_directory}/component/app.jsonnet
         input_type: jsonnet

--- a/class/gitlab-runner.yml
+++ b/class/gitlab-runner.yml
@@ -16,6 +16,7 @@ parameters:
         helm_params:
           name: gitlab-runner
           namespace: ${gitlab_runner:namespace}
+          api_versions: ${gitlab_runner:helm_params:api_versions}
       - input_paths:
           - ${_base_directory}/component/app.jsonnet
         input_type: jsonnet

--- a/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/00_namespace.yaml
+++ b/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/00_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-gitlab-runner
+  name: syn-gitlab-runner

--- a/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/configmap.yaml
+++ b/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/configmap.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+data:
+  check-live: |
+    #!/bin/bash
+    if /usr/bin/pgrep -f .*register-the-runner; then
+      exit 0
+    elif /usr/bin/pgrep gitlab.*runner; then
+      exit 0
+    else
+      exit 1
+    fi
+  config.template.toml: |
+    [[runners]]
+      [runners.kubernetes]
+        namespace = "syn-gitlab-runner"
+        image = "ubuntu:16.04"
+  config.toml: |
+    concurrent = 10
+    check_interval = 30
+    log_level = "info"
+    listen_address = ':9252'
+  entrypoint: |
+    #!/bin/bash
+    set -e
+
+    mkdir -p /home/gitlab-runner/.gitlab-runner/
+
+    cp /configmaps/config.toml /home/gitlab-runner/.gitlab-runner/
+
+    # Set up environment variables for cache
+    if [[ -f /secrets/accesskey && -f /secrets/secretkey ]]; then
+      export CACHE_S3_ACCESS_KEY=$(cat /secrets/accesskey)
+      export CACHE_S3_SECRET_KEY=$(cat /secrets/secretkey)
+    fi
+
+    if [[ -f /secrets/gcs-applicaton-credentials-file ]]; then
+      export GOOGLE_APPLICATION_CREDENTIALS="/secrets/gcs-applicaton-credentials-file"
+    elif [[ -f /secrets/gcs-application-credentials-file ]]; then
+      export GOOGLE_APPLICATION_CREDENTIALS="/secrets/gcs-application-credentials-file"
+    else
+      if [[ -f /secrets/gcs-access-id && -f /secrets/gcs-private-key ]]; then
+        export CACHE_GCS_ACCESS_ID=$(cat /secrets/gcs-access-id)
+        # echo -e used to make private key multiline (in google json auth key private key is oneline with \n)
+        export CACHE_GCS_PRIVATE_KEY=$(echo -e $(cat /secrets/gcs-private-key))
+      fi
+    fi
+
+    if [[ -f /secrets/azure-account-name && -f /secrets/azure-account-key ]]; then
+      export CACHE_AZURE_ACCOUNT_NAME=$(cat /secrets/azure-account-name)
+      export CACHE_AZURE_ACCOUNT_KEY=$(cat /secrets/azure-account-key)
+    fi
+
+    if [[ -f /secrets/runner-registration-token ]]; then
+      export REGISTRATION_TOKEN=$(cat /secrets/runner-registration-token)
+    fi
+
+    if [[ -f /secrets/runner-token ]]; then
+      export CI_SERVER_TOKEN=$(cat /secrets/runner-token)
+    fi
+
+    # Validate this also at runtime in case the user has set a custom secret
+    if [[ ! -z "$CI_SERVER_TOKEN" && "1" -ne "1" ]]; then
+      echo "Using a runner token with more than 1 replica is not supported."
+      exit 1
+    fi
+
+    # Register the runner
+    if ! sh /configmaps/register-the-runner; then
+      exit 1
+    fi
+
+    # Run pre-entrypoint-script
+    if ! bash /configmaps/pre-entrypoint-script; then
+      exit 1
+    fi
+
+    # Start the runner
+    exec /entrypoint run --user=gitlab-runner \
+      --working-directory=/home/gitlab-runner
+  pre-entrypoint-script: ''
+  register-the-runner: |
+    #!/bin/bash
+    MAX_REGISTER_ATTEMPTS=30
+
+    for i in $(seq 1 "${MAX_REGISTER_ATTEMPTS}"); do
+      echo "Registration attempt ${i} of ${MAX_REGISTER_ATTEMPTS}"
+      /entrypoint register \
+        --template-config /configmaps/config.template.toml \
+        --non-interactive
+
+      retval=$?
+
+      if [ ${retval} = 0 ]; then
+        break
+      elif [ ${i} = ${MAX_REGISTER_ATTEMPTS} ]; then
+        exit 1
+      fi
+
+      sleep 5
+    done
+
+    exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app: gitlab-runner
+    chart: gitlab-runner-0.50.1
+    heritage: Helm
+    release: gitlab-runner
+  name: gitlab-runner
+  namespace: syn-gitlab-runner

--- a/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/deployment.yaml
+++ b/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: gitlab-runner
+    chart: gitlab-runner-0.50.1
+    heritage: Helm
+    release: gitlab-runner
+  name: gitlab-runner
+  namespace: syn-gitlab-runner
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: gitlab-runner
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: 75c93fd9c747a83e1c2baf3e0b9fab26e32abe0068397e6e9bdf628f6b313367
+        checksum/secrets: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        prometheus.io/port: '9252'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: gitlab-runner
+        chart: gitlab-runner-0.50.1
+        heritage: Helm
+        release: gitlab-runner
+    spec:
+      containers:
+        - command:
+            - /usr/bin/dumb-init
+            - --
+            - /bin/bash
+            - /configmaps/entrypoint
+          env:
+            - name: CI_SERVER_URL
+              value: null
+            - name: CLONE_URL
+              value: ''
+            - name: RUNNER_EXECUTOR
+              value: kubernetes
+            - name: REGISTER_LOCKED
+              value: 'true'
+            - name: RUNNER_TAG_LIST
+              value: ''
+          image: registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v15.9.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - /configmaps/check-live
+            failureThreshold: 3
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: gitlab-runner
+          ports:
+            - containerPort: 9252
+              name: metrics
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/pgrep
+                - gitlab.*runner
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /secrets
+              name: projected-secrets
+            - mountPath: /home/gitlab-runner/.gitlab-runner
+              name: etc-gitlab-runner
+            - mountPath: /configmaps
+              name: configmaps
+      securityContext:
+        fsGroup: 65533
+        runAsUser: 100
+      serviceAccountName: ''
+      terminationGracePeriodSeconds: 3600
+      volumes:
+        - emptyDir:
+            medium: Memory
+          name: runner-secrets
+        - emptyDir:
+            medium: Memory
+          name: etc-gitlab-runner
+        - name: projected-secrets
+          projected:
+            sources:
+              - secret:
+                  items:
+                    - key: runner-registration-token
+                      path: runner-registration-token
+                    - key: runner-token
+                      path: runner-token
+                  name: gitlab-runner
+        - configMap:
+            name: gitlab-runner
+          name: configmaps

--- a/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/service.yaml
+++ b/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: gitlab-runner
+    chart: gitlab-runner-0.50.1
+    heritage: Helm
+    release: gitlab-runner
+  name: gitlab-runner
+  namespace: syn-gitlab-runner
+spec:
+  ports:
+    - name: metrics
+      port: 9252
+      targetPort: metrics
+  selector:
+    app: gitlab-runner
+    release: gitlab-runner
+  type: ClusterIP

--- a/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/servicemonitor.yaml
+++ b/tests/golden/monitoring-metrics/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: gitlab-runner
+    chart: gitlab-runner-0.50.1
+    heritage: Helm
+    release: gitlab-runner
+  name: gitlab-runner
+  namespace: syn-gitlab-runner
+spec:
+  endpoints:
+    - port: metrics
+  namespaceSelector:
+    matchNames:
+      - syn-gitlab-runner
+  selector:
+    matchLabels:
+      app: gitlab-runner
+      chart: gitlab-runner-0.50.1
+      heritage: Helm
+      release: gitlab-runner

--- a/tests/monitoring-metrics.yml
+++ b/tests/monitoring-metrics.yml
@@ -1,0 +1,11 @@
+parameters:
+  _instance: gitlab-runner-with-monitoring-and-metrics
+  gitlab_runner:
+    helm_values:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      service:
+        enabled: true
+

--- a/tests/monitoring-metrics.yml
+++ b/tests/monitoring-metrics.yml
@@ -8,4 +8,3 @@ parameters:
           enabled: true
       service:
         enabled: true
-


### PR DESCRIPTION
To enable the monitoring for the component _gitlab-runner_, helm checks if a certain api (_monitoring.coreos.com/v1_) is installed. Since helm is executed by Kapitan and not rendered against a cluster, this can't be checked and has to be added via a parameter to the templating step.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
