### PR TITLE
Add support for NamespaceLabels

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "gitlab-runner",
       "slug": "gitlab-runner",
       "parameter_key": "gitlab_runner",
-      "test_cases": "defaults registration-url monitoring-metrics",
+      "test_cases": "defaults registration-url monitoring-metrics namespaceLabels",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
           - defaults
           - registration-url
           - monitoring-metrics
+          - namespaceLabels
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -52,6 +53,7 @@ jobs:
           - defaults
           - registration-url
           - monitoring-metrics
+          - namespaceLabels
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/registration-url.yml tests/monitoring-metrics.yml
+test_instances = tests/defaults.yml tests/registration-url.yml tests/monitoring-metrics.yml tests/namespaceLabels.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,6 +3,7 @@ parameters:
     =_metadata:
       multi_instance: true
     namespace: syn-${_instance}
+    namespaceLabels: {}
     name: gitlab_runner
     charts:
       gitlab_runner:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -2,10 +2,17 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
+
 // The hiera parameters for the component
 local params = inv.parameters.gitlab_runner;
 
+local namespace = kube.Namespace(params.namespace) {
+  metadata+: {
+    labels+: params.namespaceLabels,
+  },
+};
+
 // Define outputs below
 {
-  '00_namespace': kube.Namespace(params.namespace),
+  '00_namespace': namespace,
 }

--- a/tests/golden/namespaceLabels/gitlab-runner/gitlab-runner/00_namespace.yaml
+++ b/tests/golden/namespaceLabels/gitlab-runner/gitlab-runner/00_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-gitlab-runner
+    test: label
+  name: syn-gitlab-runner

--- a/tests/golden/namespaceLabels/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/configmap.yaml
+++ b/tests/golden/namespaceLabels/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/configmap.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+data:
+  check-live: |
+    #!/bin/bash
+    if /usr/bin/pgrep -f .*register-the-runner; then
+      exit 0
+    elif /usr/bin/pgrep gitlab.*runner; then
+      exit 0
+    else
+      exit 1
+    fi
+  config.template.toml: |
+    [[runners]]
+      [runners.kubernetes]
+        namespace = "syn-gitlab-runner"
+        image = "ubuntu:16.04"
+  config.toml: |
+    concurrent = 10
+    check_interval = 30
+    log_level = "info"
+  entrypoint: |
+    #!/bin/bash
+    set -e
+
+    mkdir -p /home/gitlab-runner/.gitlab-runner/
+
+    cp /configmaps/config.toml /home/gitlab-runner/.gitlab-runner/
+
+    # Set up environment variables for cache
+    if [[ -f /secrets/accesskey && -f /secrets/secretkey ]]; then
+      export CACHE_S3_ACCESS_KEY=$(cat /secrets/accesskey)
+      export CACHE_S3_SECRET_KEY=$(cat /secrets/secretkey)
+    fi
+
+    if [[ -f /secrets/gcs-applicaton-credentials-file ]]; then
+      export GOOGLE_APPLICATION_CREDENTIALS="/secrets/gcs-applicaton-credentials-file"
+    elif [[ -f /secrets/gcs-application-credentials-file ]]; then
+      export GOOGLE_APPLICATION_CREDENTIALS="/secrets/gcs-application-credentials-file"
+    else
+      if [[ -f /secrets/gcs-access-id && -f /secrets/gcs-private-key ]]; then
+        export CACHE_GCS_ACCESS_ID=$(cat /secrets/gcs-access-id)
+        # echo -e used to make private key multiline (in google json auth key private key is oneline with \n)
+        export CACHE_GCS_PRIVATE_KEY=$(echo -e $(cat /secrets/gcs-private-key))
+      fi
+    fi
+
+    if [[ -f /secrets/azure-account-name && -f /secrets/azure-account-key ]]; then
+      export CACHE_AZURE_ACCOUNT_NAME=$(cat /secrets/azure-account-name)
+      export CACHE_AZURE_ACCOUNT_KEY=$(cat /secrets/azure-account-key)
+    fi
+
+    if [[ -f /secrets/runner-registration-token ]]; then
+      export REGISTRATION_TOKEN=$(cat /secrets/runner-registration-token)
+    fi
+
+    if [[ -f /secrets/runner-token ]]; then
+      export CI_SERVER_TOKEN=$(cat /secrets/runner-token)
+    fi
+
+    # Validate this also at runtime in case the user has set a custom secret
+    if [[ ! -z "$CI_SERVER_TOKEN" && "1" -ne "1" ]]; then
+      echo "Using a runner token with more than 1 replica is not supported."
+      exit 1
+    fi
+
+    # Register the runner
+    if ! sh /configmaps/register-the-runner; then
+      exit 1
+    fi
+
+    # Run pre-entrypoint-script
+    if ! bash /configmaps/pre-entrypoint-script; then
+      exit 1
+    fi
+
+    # Start the runner
+    exec /entrypoint run --user=gitlab-runner \
+      --working-directory=/home/gitlab-runner
+  pre-entrypoint-script: ''
+  register-the-runner: |
+    #!/bin/bash
+    MAX_REGISTER_ATTEMPTS=30
+
+    for i in $(seq 1 "${MAX_REGISTER_ATTEMPTS}"); do
+      echo "Registration attempt ${i} of ${MAX_REGISTER_ATTEMPTS}"
+      /entrypoint register \
+        --template-config /configmaps/config.template.toml \
+        --non-interactive
+
+      retval=$?
+
+      if [ ${retval} = 0 ]; then
+        break
+      elif [ ${i} = ${MAX_REGISTER_ATTEMPTS} ]; then
+        exit 1
+      fi
+
+      sleep 5
+    done
+
+    exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app: gitlab-runner
+    chart: gitlab-runner-0.50.1
+    heritage: Helm
+    release: gitlab-runner
+  name: gitlab-runner
+  namespace: syn-gitlab-runner

--- a/tests/golden/namespaceLabels/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/deployment.yaml
+++ b/tests/golden/namespaceLabels/gitlab-runner/gitlab-runner/01_gitlab_runner_helmchart/gitlab-runner/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: gitlab-runner
+    chart: gitlab-runner-0.50.1
+    heritage: Helm
+    release: gitlab-runner
+  name: gitlab-runner
+  namespace: syn-gitlab-runner
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: gitlab-runner
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: 24bd53325d30f0618bea69bea30a8c155b4c5fe34e1748409da6bb3d5f4edead
+        checksum/secrets: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      labels:
+        app: gitlab-runner
+        chart: gitlab-runner-0.50.1
+        heritage: Helm
+        release: gitlab-runner
+    spec:
+      containers:
+        - command:
+            - /usr/bin/dumb-init
+            - --
+            - /bin/bash
+            - /configmaps/entrypoint
+          env:
+            - name: CI_SERVER_URL
+              value: null
+            - name: CLONE_URL
+              value: ''
+            - name: RUNNER_EXECUTOR
+              value: kubernetes
+            - name: REGISTER_LOCKED
+              value: 'true'
+            - name: RUNNER_TAG_LIST
+              value: ''
+          image: registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v15.9.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - /configmaps/check-live
+            failureThreshold: 3
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: gitlab-runner
+          ports:
+            - containerPort: 9252
+              name: metrics
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/pgrep
+                - gitlab.*runner
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /secrets
+              name: projected-secrets
+            - mountPath: /home/gitlab-runner/.gitlab-runner
+              name: etc-gitlab-runner
+            - mountPath: /configmaps
+              name: configmaps
+      securityContext:
+        fsGroup: 65533
+        runAsUser: 100
+      serviceAccountName: ''
+      terminationGracePeriodSeconds: 3600
+      volumes:
+        - emptyDir:
+            medium: Memory
+          name: runner-secrets
+        - emptyDir:
+            medium: Memory
+          name: etc-gitlab-runner
+        - name: projected-secrets
+          projected:
+            sources:
+              - secret:
+                  items:
+                    - key: runner-registration-token
+                      path: runner-registration-token
+                    - key: runner-token
+                      path: runner-token
+                  name: gitlab-runner
+        - configMap:
+            name: gitlab-runner
+          name: configmaps

--- a/tests/namespaceLabels.yml
+++ b/tests/namespaceLabels.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/namespaceLabels.yml
+++ b/tests/namespaceLabels.yml
@@ -1,3 +1,4 @@
-# Overwrite parameters here
-
-# parameters: {...}
+parameters:
+  gitlab_runner:
+    namespaceLabels:
+      test: label


### PR DESCRIPTION
To allow configuring Namespace labels e.q. for `serviceMonitorNamespaceSelector`, the main.jsonet was extended.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
